### PR TITLE
Secondary beam breaks

### DIFF
--- a/src/render/vex/vxMeasure.ts
+++ b/src/render/vex/vxMeasure.ts
@@ -364,6 +364,7 @@ export class VxMeasure implements VxMeasureIf {
         vexNotes.push(vexNote);  
       }
       const vexBeam = new VF.Beam(vexNotes);
+      vexBeam.breakSecondaryAt(bg.secondaryBeamBreaks);
       this.beamToVexMap[bg.attrs.id] = vexBeam;
       this.vexBeamGroups.push(vexBeam);
     }

--- a/src/smo/data/measure.ts
+++ b/src/smo/data/measure.ts
@@ -64,6 +64,7 @@ export interface MeasureTick {
  */
 export interface ISmoBeamGroup {
   notes: SmoNote[],
+  secondaryBeamBreaks: number[],
   voice: number,
   attrs: SmoAttrs
 }

--- a/src/smo/data/tuplet.ts
+++ b/src/smo/data/tuplet.ts
@@ -144,6 +144,30 @@ export class SmoTupletTree {
     }
   }
 
+  /**
+   * Determines whether two notes are part of the same tuplet.
+   *
+   * - Returns `true` if neither `noteOne` nor `noteTwo` is part of a tuplet.
+   * - Returns `true` if both notes are part of a tuplet and share the same `tupletId`.
+   * - Returns `false` otherwise.
+   *
+   * @param noteOne
+   * @param noteTwo
+   */
+  static areNotesPartOfTheSameTuplet(noteOne: SmoNote, noteTwo: SmoNote): boolean {
+    if (typeof(noteOne.tupletId) === 'undefined' && typeof(noteTwo.tupletId) === 'undefined') {
+      return true;
+    }
+    if (noteOne.tupletId === null && noteTwo.tupletId === null) {
+      return true;
+    }
+    if (noteOne.isTuplet && noteTwo.isTuplet && noteOne.tupletId == noteTwo.tupletId) {
+      return true;
+    }
+
+    return false;
+  }
+
   serialize(): SmoTupletTreeParamsSer {
     const params = {
       ctor: 'SmoTupletTree',

--- a/src/smo/data/tuplet.ts
+++ b/src/smo/data/tuplet.ts
@@ -146,26 +146,19 @@ export class SmoTupletTree {
 
   /**
    * Determines whether two notes are part of the same tuplet.
-   *
-   * - Returns `true` if neither `noteOne` nor `noteTwo` is part of a tuplet.
-   * - Returns `true` if both notes are part of a tuplet and share the same `tupletId`.
-   * - Returns `false` otherwise.
-   *
    * @param noteOne
    * @param noteTwo
    */
   static areNotesPartOfTheSameTuplet(noteOne: SmoNote, noteTwo: SmoNote): boolean {
-    if (typeof(noteOne.tupletId) === 'undefined' && typeof(noteTwo.tupletId) === 'undefined') {
-      return true;
-    }
-    if (noteOne.tupletId === null && noteTwo.tupletId === null) {
-      return true;
-    }
-    if (noteOne.isTuplet && noteTwo.isTuplet && noteOne.tupletId == noteTwo.tupletId) {
+    if (noteOne.tupletId === noteTwo.tupletId) {
       return true;
     }
 
     return false;
+  }
+
+  static areTupletsBothNull(noteOne: SmoNote, noteTwo: SmoNote): boolean {
+    return (noteOne.tupletId ?? null) === null && (noteTwo.tupletId ?? null) === null;
   }
 
   serialize(): SmoTupletTreeParamsSer {

--- a/src/smo/xform/beamers.ts
+++ b/src/smo/xform/beamers.ts
@@ -159,8 +159,13 @@ export class SmoBeamer {
       return;
     }
 
-    if (this.currentGroup.length > 0 && !SmoTupletTree.areNotesPartOfTheSameTuplet(tickmap.notes[index - 1], tickmap.notes[index])) {
-      this.secondaryBeamBreaks.push(this.currentGroup.length - 1);
+    if (this.currentGroup.length > 0) {
+      const areTupletsBothNull = SmoTupletTree.areTupletsBothNull(tickmap.notes[index - 1], tickmap.notes[index]);
+      const areNotesPartOfTheSameTuplet = SmoTupletTree.areNotesPartOfTheSameTuplet(tickmap.notes[index - 1], tickmap.notes[index]);
+
+      if (!areTupletsBothNull && !areNotesPartOfTheSameTuplet) {
+        this.secondaryBeamBreaks.push(this.currentGroup.length - 1);
+      }
     }
 
     // beam tuplets

--- a/src/smo/xform/beamers.ts
+++ b/src/smo/xform/beamers.ts
@@ -6,12 +6,14 @@ import { SmoAttrs, getId } from '../data/common';
 import { SmoMeasure, ISmoBeamGroup } from '../data/measure';
 import { TickMap } from './tickMap';
 import { smoSerialize } from '../../common/serializationHelpers';
+import {SmoTuplet, SmoTupletTree} from "../data/tuplet";
 
 /**
  * @category SmoTransform
  */
 export interface SmoBeamGroupParams {
   notes: SmoNote[],
+  secondaryBeamBreaks: number[];
   voice: number
 }
 
@@ -21,12 +23,14 @@ export interface SmoBeamGroupParams {
  */
 export class SmoBeamGroup implements ISmoBeamGroup {
   notes: SmoNote[];
+  secondaryBeamBreaks: number[];
   attrs: SmoAttrs;
   voice: number = 0;
   constructor(params: SmoBeamGroupParams) {
     let i = 0;
     this.voice = params.voice;
     this.notes = params.notes;
+    this.secondaryBeamBreaks = params.secondaryBeamBreaks;
     smoSerialize.vexMerge(this, params);
 
     this.attrs = {
@@ -65,6 +69,7 @@ export class SmoBeamer {
   beamBeats: number;
   skipNext: number;
   currentGroup: SmoNote[];
+  secondaryBeamBreaks: number[];
   constructor(measure: SmoMeasure, voice: number) {
     this.measure = measure;
     this._removeVoiceBeam(measure, voice);
@@ -78,6 +83,7 @@ export class SmoBeamer {
     }
     this.skipNext = 0;
     this.currentGroup = [];
+    this.secondaryBeamBreaks = [];
   }
 
   get beamGroups() {
@@ -101,6 +107,7 @@ export class SmoBeamer {
     if (nrCount.length > 1) {
       this.measure.beamGroups.push(new SmoBeamGroup({
         notes: this.currentGroup,
+        secondaryBeamBreaks: this.secondaryBeamBreaks,
         voice
       }));
     }
@@ -108,6 +115,7 @@ export class SmoBeamer {
 
   _advanceGroup() {
     this.currentGroup = [];
+    this.secondaryBeamBreaks = [];
     this.duration = 0;
   }
 
@@ -151,40 +159,28 @@ export class SmoBeamer {
       return;
     }
 
+    if (this.currentGroup.length > 0 && !SmoTupletTree.areNotesPartOfTheSameTuplet(tickmap.notes[index - 1], tickmap.notes[index])) {
+      this.secondaryBeamBreaks.push(this.currentGroup.length - 1);
+    }
+
     // beam tuplets
-    // if (note.isTuplet) {
-    //   const tuplet = this.measure.getTupletForNote(note);
-    //   // The underlying notes must have been deleted.
-    //   if (!tuplet) {
-    //     return;
-    //   }
+    if (note.isTuplet) {
+      const tupletTree = SmoTupletTree.getTupletTreeForNoteIndex(this.measure.tupletTrees, tickmap.voice, index);
+      if (!tupletTree) {
+        return;
+      }
 
-    //   const first = tuplet.getFirstNote();
-    //   if (!first) {
-    //     return;
-    //   }
-
-    //   const ult = tuplet.getLastNote();
-    //   if (!ult) {
-    //     return;
-    //   }
-
-    //   if (first.endBeam) {
-    //     this._advanceGroup();
-    //     return;
-    //   }
-
-    //   // is this beamable length-wise
-    //   if (note.noteType === 'n' && note.stemTicks < 4096) {
-    //     this.currentGroup.push(note);
-    //   }
-    //   // Ultimate note in tuplet
-    //   if (ult.attrs.id === note.attrs.id && !this._isRemainingTicksBeamable(tickmap, index)) {
-    //     this._completeGroup(tickmap.voice);
-    //     this._advanceGroup();
-    //   }
-    //   return;
-    // }
+      // is this beamable length-wise
+      if (note.noteType === 'n' && note.stemTicks < 4096) {
+        this.currentGroup.push(note);
+      }
+      // Ultimate note in tuplet
+      if (tupletTree.endIndex == index && !this._isRemainingTicksBeamable(tickmap, index)) {
+        this._completeGroup(tickmap.voice);
+        this._advanceGroup();
+      }
+      return;
+    }
 
     // don't beam > 1/4 note in 4/4 time.  Don't beam rests.
     if (note.stemTicks >= 4096 || (note.isRest() && this.currentGroup.length === 0)) {
@@ -193,33 +189,32 @@ export class SmoBeamer {
       return;
     }
 
-    //if areTupletElementsDifferent(noteOne, noteTwo)
-    //this._completeGroup(tickmap.voice);
-    //this._advanceGroup();
-    if (index > 0 && !SmoBeamer.areTupletElementsTheSame(tickmap.notes[index - 1], tickmap.notes[index])) {
-      this._completeGroup(tickmap.voice);
-      this._advanceGroup();
-    }
-
     this.currentGroup.push(note);
+
     if (note.endBeam) {
       this._completeGroup(tickmap.voice);
       this._advanceGroup();
     }
-    if (this.measure.timeSignature.actualBeats % 4 === 0) {
-        if (this.duration < 8192 && this.allEighth()) {
-          return;
-        } else if (this.duration === 8192) {
-          this._completeGroup(tickmap.voice);
-          this._advanceGroup();
-        }
-    }
-    // If we are aligned to a beat on the measure, and we are in common time
-    if (this.currentGroup.length > 1 && this.measure.timeSignature.beatDuration === 4 &&
-      this.measureDuration % 4096 === 0) {
+    if (index == tickmap.notes.length - 1) {
+      //Last note in the voice. We are closing the beam with whatever has been put there
       this._completeGroup(tickmap.voice);
       this._advanceGroup();
       return;
+    }
+
+    if (this.measure.timeSignature.actualBeats % 4 === 0) {
+      if (this.duration < 8192 && this.allEighth()) {
+        return;
+      } else if (this.duration === 8192) {
+        this._completeGroup(tickmap.voice);
+        this._advanceGroup();
+      }
+    }
+    // If we are aligned to a beat on the measure, and we are in common time
+    if (this.currentGroup.length > 1 && this.measure.timeSignature.beatDuration === 4 && this.measureDuration % 4096 === 0) {
+        this._completeGroup(tickmap.voice);
+        this._advanceGroup();
+        return;
     }
     if (this.duration === this.beamBeats) {
       this._completeGroup(tickmap.voice);
@@ -232,19 +227,4 @@ export class SmoBeamer {
       this._advanceGroup();
     }
   }
-
-  public static areTupletElementsTheSame(noteOne: SmoNote, noteTwo: SmoNote): boolean {
-    if (typeof(noteOne.tupletId) === 'undefined' && typeof(noteTwo.tupletId) === 'undefined') {
-      return true;
-    }
-    if (noteOne.tupletId === null && noteTwo.tupletId === null) {
-      return true;
-    }
-    if (noteOne.isTuplet && noteTwo.isTuplet && noteOne.tupletId == noteTwo.tupletId) {
-      return true;
-    }
-
-    return false;
-  }
-
 }

--- a/src/smo/xform/tickDuration.ts
+++ b/src/smo/xform/tickDuration.ts
@@ -252,7 +252,10 @@ export class SmoStretchNoteActor extends TickIteratorBase {
     for (let i = this.startIndex + 1; i < this.notes.length; ++i) {
       const nextNote = this.notes[i];
 
-      if (!SmoTupletTree.areNotesPartOfTheSameTuplet(originalNote, nextNote)) {
+      const areTupletsBothNull = SmoTupletTree.areTupletsBothNull(originalNote, nextNote);
+      const areNotesPartOfTheSmeTuplet = SmoTupletTree.areNotesPartOfTheSameTuplet(originalNote, nextNote);
+
+      if (!areTupletsBothNull && !areNotesPartOfTheSmeTuplet) {
         crossedTupletBoundary = true;
         break;
       }

--- a/src/smo/xform/tickDuration.ts
+++ b/src/smo/xform/tickDuration.ts
@@ -220,53 +220,88 @@ export class SmoStretchNoteActor extends TickIteratorBase {
     this.notes = this.measure.voices[this.voice].notes;
 
     const originalNote: SmoNote = this.notes[this.startIndex];
-    let newTicks: Ticks = { numerator: this.newStemTicks, denominator: 1, remainder: 0 };
     const multiplier = originalNote.tickCount / originalNote.stemTicks;
-    if (originalNote.isTuplet) {
-      const numerator = this.newStemTicks * multiplier;
-      newTicks = { numerator: Math.floor(numerator), denominator: 1, remainder: numerator % 1 };
-    } 
+
+    const newTicks = this.calculateNewTicks(originalNote, multiplier);
 
     const replacingNote = SmoNote.cloneWithDuration(originalNote, newTicks, this.newStemTicks);
 
+    const {stemTicksUsed, crossedTupletBoundary} = this.determineNotesToDelete(originalNote);
+
+    // if crossing a tuplet boundary, abort stretching
+    if (crossedTupletBoundary) {
+      this.numberOfNotesToDelete = 0;
+    } else {
+      this.prepareNotesToInsert(originalNote, replacingNote, stemTicksUsed, multiplier);
+    }
+  }
+
+  private calculateNewTicks(originalNote: SmoNote, multiplier: number): Ticks {
+    if (originalNote.isTuplet) {
+      const numerator = this.newStemTicks * multiplier
+      return { numerator: Math.floor(numerator), denominator: 1, remainder: numerator % 1};
+    } else {
+      return { numerator: this.newStemTicks, denominator: 1, remainder: 0};
+    }
+  }
+
+  private determineNotesToDelete(originalNote: SmoNote) {
+    let crossedTupletBoundary = false;
     let stemTicksUsed = originalNote.stemTicks;
+
     for (let i = this.startIndex + 1; i < this.notes.length; ++i) {
-      const nnote = this.notes[i];
-      //in case notes are part of the tuplet they need to belong to the same tuplet
-      //this check is only temporarely here, it should never come to this
-      if (nnote.isTuplet && !this.areNotesInSameTuplet(originalNote, nnote)) {
+      const nextNote = this.notes[i];
+
+      if (!SmoTupletTree.areNotesPartOfTheSameTuplet(originalNote, nextNote)) {
+        crossedTupletBoundary = true;
         break;
       }
-      stemTicksUsed += nnote.stemTicks;
+
+      stemTicksUsed += nextNote.stemTicks;
       ++this.numberOfNotesToDelete;
+
       if (stemTicksUsed >= this.newStemTicks) {
         break;
       }
     }
-    const remainingAmount = stemTicksUsed - this.newStemTicks;
-    if (remainingAmount >= 0) {
+
+    return {stemTicksUsed, crossedTupletBoundary};
+  }
+
+  private prepareNotesToInsert(
+      originalNote: SmoNote,
+      replacingNote: SmoNote,
+      stemTicksUsed: number,
+      multiplier: number
+  ) {
+    const remainingTicks = stemTicksUsed - this.newStemTicks;
+
+    if (remainingTicks >= 0) {
       this.notesToInsert.push(replacingNote);
-      const lmap = SmoMusic.gcdMap(remainingAmount);
-      lmap.forEach((stemTick) => {
+
+      const tickMap = SmoMusic.gcdMap(remainingTicks);
+      tickMap.forEach((stemTick) => {
         const numerator = stemTick * multiplier;
-        const nnote = SmoNote.cloneWithDuration(originalNote, {numerator: Math.floor(numerator), denominator: 1, remainder: numerator % 1}, stemTick)
-        this.notesToInsert.push(nnote);
+        const newNote = SmoNote.cloneWithDuration(originalNote, {numerator: Math.floor(numerator), denominator: 1, remainder: numerator % 1}, stemTick)
+        this.notesToInsert.push(newNote);
       });
+
+      // Adjust tuplet indexes due to note insertion/deletion
       const noteCountDiff = (this.notesToInsert.length - this.numberOfNotesToDelete) - 1;
       SmoTupletTree.adjustTupletIndexes(this.measure.tupletTrees, this.voice, this.startIndex, noteCountDiff);
 
       //accumulate all remainders in the first note
-      let remainder: number = 0;
+      let totalRemainder: number = 0;
       this.notesToInsert.forEach((note: SmoNote) => {
         if (note.ticks.remainder > 0) {
-          remainder += note.ticks.remainder;
+          totalRemainder += note.ticks.remainder;
           note.ticks.remainder = 0;
         }
       });
-      this.notesToInsert[0].ticks.numerator += Math.round(remainder);
-
+      this.notesToInsert[0].ticks.numerator += Math.round(totalRemainder);
     }
   }
+
   static apply(params: SmoStretchNoteParams) {
     const actor = new SmoStretchNoteActor(params);
     SmoTickIterator.iterateOverTicks(actor.measure, actor, actor.voice);
@@ -279,13 +314,6 @@ export class SmoStretchNoteActor extends TickIteratorBase {
       return [];
     } 
     return null;
-  }
-
-  private areNotesInSameTuplet(noteOne: SmoNote, noteTwo: SmoNote): boolean {
-    if (noteOne.isTuplet && noteTwo.isTuplet && noteOne.tupletId == noteTwo.tupletId) {
-      return true;
-    }
-    return false;
   }
 }
 

--- a/src/ui/dialogs/components/rocker.ts
+++ b/src/ui/dialogs/components/rocker.ts
@@ -120,12 +120,16 @@ export class SuiRockerComponent extends SuiComponentBase {
       () => {
         val = (this as any)[this.parser]();
         if (val !== this.initialValue) {
+          this.initialValue = val;
+          if (this.dataType === 'percent') {
+            val = 100 * val;
+          }
           if (this.min != undefined && val < this.min) {
             val = this.min;
           } else if (this.max != undefined && val > this.max) {
             val = this.max;
           }
-          this.initialValue = val;
+          $(input).val(val);
           this.handleChanged();
         }
       }


### PR DESCRIPTION

<img width="303" alt="Screenshot 2024-11-21 at 22 47 15" src="https://github.com/user-attachments/assets/cef3912b-785d-4f16-9384-1a066d8b2d66">

The main purpose of this PR is the addition of secondary beam breaks, but while working on this, I touched a few other places.
1) Fix on rocker component's "onblur" and "offblur" events.
2) It was possible to increase the duration of the last note in a tuplet. I also did some refactoring of the SmoStretchNoteActor class. Hopefully it is more readable now.
