### PR TITLE
Mapping of mouse to music is off for very large scores

### DIFF
--- a/src/render/sui/svgPageMap.ts
+++ b/src/render/sui/svgPageMap.ts
@@ -496,7 +496,6 @@ export class SvgPageMap {
       const x = (box.x - this.containerOffset.x) / cof;
       const y = (box.y - this.containerOffset.y) / cof;
       const logicalBox = SvgHelpers.boxPoints(x, y, Math.max(box.width / cof, 1), Math.max(box.height / cof, 1));
-      logicalBox.y -= Math.round(logicalBox.y / this.layout.pageHeight) / this.layout.svgScale;
       if (layoutDebug.mask | layoutDebug.values['mouseDebug']) {
         layoutDebug.updateMouseDebug(box, logicalBox, this.containerOffset);
       }


### PR DESCRIPTION
It seems that removing this one line of code fixed the position calculation.
